### PR TITLE
Fix breaking changes released by Google Firebase on Jun 17, 2019

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .build-browser
 package-lock.json
 node_modules
+lib/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This plugin brings push notifications, analytics, event tracking, crash reporting and more from Google Firebase to your Cordova project!
 
+## 4.0.0 - Breaking Change
+
+Minimum `v8.0.0` of `cordova-android` is now required. View https://github.com/wizpanda/cordova-plugin-firebase-lib/pull/13 for details.
+
 ## Difference from the fork repository
 
 Maintained by [Wiz Panda](https://www.wizpanda.com/).
@@ -26,7 +30,7 @@ For the changes on the next versions, please check the [CHANGELOG.md](https://gi
 ## Supported Cordova Versions
 
 - cordova: `>= 7`
-- cordova-android: `>= 7.0.0`
+- cordova-android: `>= 8.0.0`
 - cordova-ios: `>= 4.5.5`
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -16,36 +16,41 @@ The [author](https://github.com/arnesson) did a great job on the plugin. But see
 thought to maintain the repository with the latest changes & fixes so the others can take benefit of the Firebase in their cordova 
 application.
 
-Here are the following changes in the first version i.e. 3.0.0
-
-1. Cordova@9 support
-2. Fixes issues cause by Firebase SDK updates on [5 April 2019](https://firebase.google.com/support/release-notes/android#update_-_april_05_2019).
-Thanks to [Dave Alden](https://github.com/dpa99c) for [commit](https://github.com/wizpanda/cordova-plugin-firebase-lib/commit/46a7bd1c06434fb4c5a72c2c20ae5d951a2e37f4)
-3. Remove obsolete <service> entry for FirebasePluginInstanceIDService. Thanks to [Dave Alden](https://github.com/dpa99c) for [commit](https://github.com/wizpanda/cordova-plugin-firebase-lib/commit/eee2cfe845e6c2466d4c7fcb69d70c0c8840ea6b)
-4. Remove unnecessary extra <config-file> block which can lead to race condition. Thanks to [Dave Alden](https://github.com/dpa99c) for [commit](https://github.com/wizpanda/cordova-plugin-firebase-lib/commit/17eb7c46176d5ad28fc93b53a2c49d9e6ed1888b)
-5. Remove redundant build-extras.gradle. Thanks to [Dave Alden](https://github.com/dpa99c) for [commit](https://github.com/wizpanda/cordova-plugin-firebase-lib/commit/289706fc30fe848de082c468440c91ffecdce97d)
-
-For the changes on the next versions, please check the [CHANGELOG.md](https://github.com/wizpanda/cordova-plugin-firebase-lib/blob/master/CHANGELOG.md)
-
-## Supported Cordova Versions
-
-- cordova: `>= 7`
-- cordova-android: `>= 8.0.0`
-- cordova-ios: `>= 4.5.5`
+To see a full list of changes done after we started maintaining this fork, please see the [Releases](https://github.com/wizpanda/cordova-plugin-firebase-lib/releases)
+or read the [CHANGELOG.md](https://github.com/wizpanda/cordova-plugin-firebase-lib/blob/master/CHANGELOG.md#v300)
 
 ## Installation
 
-Install the plugin by adding it to your project's `config.xml`:
+### For `cordova-android >= 8.x.x`
 
-```xml
-<plugin name="cordova-plugin-firebase-lib" spec="^3.0.0" />
-```
+Since `v4.0.0`, this plugin no longer support `cordova-android 7.x.x` because of the breaking change released by Google on Jun 17, 2019. 
+See https://github.com/wizpanda/cordova-plugin-firebase-lib/pull/13
 
-or by running:
+To install the latest version, run the following in your terminal:
 
 ```bash
 cordova plugin add cordova-plugin-firebase-lib --save
 ```
+
+### For `cordova-android 7.x.x`
+
+Run the following in your terminal:
+
+```bash
+cordova plugin add cordova-plugin-firebase-lib@3.3.0 --save
+```
+
+Or add the following in your `config.xml`:
+
+```xml
+<plugin name="cordova-plugin-firebase-lib" spec="^3.3.0" />
+```
+
+## Supported Cordova Versions
+
+- cordova: `>= 8`
+- cordova-android: `>= 8.0.0`
+- cordova-ios: `>= 4.5.5`
 
 ### Guides
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,11 +49,11 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
 		<framework src="com.google.android.gms:play-services-tagmanager:16.+" />
-		<framework src="com.google.firebase:firebase-auth:17.+" />
-		<framework src="com.google.firebase:firebase-core:16.+" />
-		<framework src="com.google.firebase:firebase-messaging:18.+" />
-		<framework src="com.google.firebase:firebase-config:17.+" />
-		<framework src="com.google.firebase:firebase-perf:17.+" />
+		<framework src="com.google.firebase:firebase-auth:18.+" />
+		<framework src="com.google.firebase:firebase-core:17.+" />
+		<framework src="com.google.firebase:firebase-messaging:19.+" />
+		<framework src="com.google.firebase:firebase-config:18.+" />
+		<framework src="com.google.firebase:firebase-perf:18.+" />
 	</platform>
 
 	<platform name="ios">

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,6 +8,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<engines>
 		<engine name="cordova" version=">=7.0.0"/>
+		<engine name="cordova-android" version=">=8.0.0"/>
 	</engines>
 
 	<platform name="android">

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -8,7 +8,6 @@
  * Credits: https://github.com/arnesson.
  */
 var fs = require('fs');
-var path = require('path');
 var utilities = require("./lib/utilities");
 
 var config = fs.readFileSync('config.xml').toString();

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -6,7 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.support.v4.app.NotificationManagerCompat;
+import androidx.core.app.NotificationManagerCompat;
 import android.util.Base64;
 import android.util.Log;
 
@@ -14,7 +14,7 @@ import android.annotation.TargetApi;
 import android.app.NotificationChannel;
 import android.content.ContentResolver;
 import android.os.Build;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 import android.media.AudioAttributes;
 import android.net.Uri;
 

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -8,7 +8,7 @@ import android.content.Intent;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 import android.util.Log;
 import android.app.Notification;
 import android.text.TextUtils;

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        google()
         jcenter()
         mavenCentral()
     }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         jcenter()
         mavenCentral()
     }
@@ -7,6 +8,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.1.0'
     }
 }
+
 repositories {
     mavenCentral()
     maven {


### PR DESCRIPTION
On Jun 17, 2019, Google [released](https://firebase.google.com/support/release-notes/android#update_-_june_17_2019) some breaking changes:

![image](https://user-images.githubusercontent.com/1804514/59721950-18042d80-9240-11e9-8894-f8e2925f04b4.png)

Now, the first necessary change we need to make is:

> Upgrade com.android.tools.build:gradle to v3.2.1 or later.

Now as per Android's [gradle-plugin](https://developer.android.com/studio/releases/gradle-plugin): to support a minimum of `v3.2.1`, we need to use `Gradle 4.6`:

![image](https://user-images.githubusercontent.com/1804514/59722308-f9eafd00-9240-11e9-8c93-c057a108b93d.png)

But the `cordova-android<=7.1.4` uses `Gradle 4.1` so we need to upgrade the `cordova-android` to a minimum of `v8.0.0` as Gradle has been upgraded to `Gradle 4.10.1` https://github.com/apache/cordova-android/blob/rel/8.0.0/RELEASENOTES.md#800-feb-13-2019

## So cordova-android >= 8.0.0 is required on this plugin now.

Although, you can upgrade the Gradle manually in your existing `cordova-android 7.x` versions but that will require many manual changes.

This PR support the latest builds shipped by Firebase.