### PR TITLE
Backward compatibility fixes to support breaking changes released by Google Firebase on Jun 17, 2019

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -48,11 +48,12 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
-		<framework src="com.google.android.gms:play-services-tagmanager:+" />
-		<framework src="com.google.firebase:firebase-core:+" />
-		<framework src="com.google.firebase:firebase-messaging:+" />
-		<framework src="com.google.firebase:firebase-config:+" />
-		<framework src="com.google.firebase:firebase-perf:+" />
+		<framework src="com.google.android.gms:play-services-tagmanager:16.+" />
+		<framework src="com.google.firebase:firebase-auth:17.+" />
+		<framework src="com.google.firebase:firebase-core:16.+" />
+		<framework src="com.google.firebase:firebase-messaging:18.+" />
+		<framework src="com.google.firebase:firebase-config:17.+" />
+		<framework src="com.google.firebase:firebase-perf:17.+" />
 	</platform>
 
 	<platform name="ios">

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -4,7 +4,6 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:+'
         classpath 'com.google.gms:google-services:4.1.0'
     }
 }
@@ -17,9 +16,8 @@ repositories {
 
 dependencies {
     compile 'me.leolin:ShortcutBadger:1.1.4@aar'
-    compile 'com.google.firebase:firebase-auth:+'
     compile('com.crashlytics.sdk.android:crashlytics:2.9.1@aar') {
-       transitive = true
+        transitive = true
     }
 }
 


### PR DESCRIPTION
On Jun 17, 2019, Google [released](https://firebase.google.com/support/release-notes/android#update_-_june_17_2019) some breaking changes:

![image](https://user-images.githubusercontent.com/1804514/59721950-18042d80-9240-11e9-8894-f8e2925f04b4.png)

This PR provides backward compatible support for `cordova-android 7.x.x`. Version 3.x of this plugin will be the last release to support `cordova-android 7.x.x`.

For the next major version of this plugin, see #13 