### PR TITLE
Fix for ampersand in the app name

### DIFF
--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -12,6 +12,9 @@ const utilities = require("./lib/utilities");
 
 const config = fs.readFileSync('config.xml').toString();
 const name = utilities.getValue(config, 'name');
+if(name.includes("&amp;")){
+    name = name.replace(/&amp;/g, '&');
+}
 
 const IOS_DIR = 'platforms/ios';
 const ANDROID_DIR = 'platforms/android';

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 const utilities = require("./lib/utilities");
 
 const config = fs.readFileSync('config.xml').toString();
-const name = utilities.getValue(config, 'name');
+var name = utilities.getValue(config, 'name');
 if(name.includes("&amp;")){
     name = name.replace(/&amp;/g, '&');
 }


### PR DESCRIPTION
If there is a '&' in the app name for iOS, the build fails b/c it fails to copy the files to correct location. This will fix that issue. 