### PR TITLE
Downgrading Fireabse iOS dependency to 5.x to keep running existing code

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,14 +2,16 @@
 <plugin id="cordova-plugin-firebase-lib" version="5.0.0"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
-    <name>Google Firebase Plugin</name>
 
+    <name>Google Firebase Plugin</name>
+    <description>Cordova plugin for Firebase integration</description>
+    <keywords>cordova</keywords>
     <license>MIT</license>
 
     <engines>
         <engine name="cordova" version=">=9.0.0"/>
         <engine name="cordova-android" version=">=8.0.0"/>
-        <engine name="cordova-ios" version=">=5.0.1"/>
+        <engine name="cordova-ios" version=">=5.0.0"/>
     </engines>
 
     <platform name="android">
@@ -91,12 +93,12 @@
             <config>
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
-            <pods>
-                <pod name="Firebase/Core" spec="~> 6.1.0"/>
-                <pod name="Firebase/Auth" spec="~> 6.1.0"/>
-                <pod name="Firebase/Messaging" spec="~> 6.1.0"/>
-                <pod name="Firebase/Performance" spec="~> 6.1.0"/>
-                <pod name="Firebase/RemoteConfig" spec="~> 6.1.0"/>
+            <pods use-frameworks="true">
+                <pod name="Firebase/Core" spec="5.20.2"/>
+                <pod name="Firebase/Auth" spec="5.20.2"/>
+                <pod name="Firebase/Messaging" spec="5.20.2"/>
+                <pod name="Firebase/Performance" spec="5.20.2"/>
+                <pod name="Firebase/RemoteConfig" spec="5.20.2"/>
                 <pod name="Fabric" spec="1.10.2"/>
                 <pod name="Crashlytics" spec="3.13.2"/>
             </pods>

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -178,10 +178,7 @@ public class FirebasePlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-        if (action.equals("getInstanceId")) {
-            this.getInstanceId(callbackContext);
-            return true;
-        } else if (action.equals("getId")) {
+        if (action.equals("getId")) {
             this.getId(callbackContext);
             return true;
         } else if (action.equals("getToken")) {
@@ -400,20 +397,6 @@ public class FirebasePlugin extends CordovaPlugin {
             data.putBoolean("tap", true);
             FirebasePlugin.sendNotification(data, this.cordova.getActivity().getApplicationContext());
         }
-    }
-
-    // DEPRECTED - alias of getToken
-    private void getInstanceId(final CallbackContext callbackContext) {
-        cordova.getThreadPool().execute(new Runnable() {
-            public void run() {
-                try {
-                    String token = FirebaseInstanceId.getInstance().getToken();
-                    callbackContext.success(token);
-                } catch (Exception e) {
-                    callbackContext.error(e.getMessage());
-                }
-            }
-        });
     }
 
     private void getId(final CallbackContext callbackContext) {

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -5,7 +5,6 @@
 + (FirebasePlugin *) firebasePlugin;
 - (void)getVerificationID:(CDVInvokedUrlCommand*)command;
 - (void)verifyPhoneNumber:(CDVInvokedUrlCommand*)command;
-- (void)getInstanceId:(CDVInvokedUrlCommand*)command;
 - (void)getId:(CDVInvokedUrlCommand*)command;
 - (void)getToken:(CDVInvokedUrlCommand*)command;
 - (void)grantPermission:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -54,12 +54,6 @@ static FirebasePlugin *firebasePlugin;
     [[FIRInstanceID instanceID] getIDWithHandler:handler];
 }
 
-// DEPRECATED - alias of getToken
-- (void)getInstanceId:(CDVInvokedUrlCommand *)command {
-    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[FIRInstanceID instanceID] token]];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-}
-
 - (void)getToken:(CDVInvokedUrlCommand *)command {
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[FIRInstanceID instanceID] token]];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/www/firebase-browser.js
+++ b/www/firebase-browser.js
@@ -4,12 +4,6 @@ exports.getVerificationID = function (number, success, error) {
     }
 };
 
-exports.getInstanceId = function (success, error) {
-    if (typeof success === 'function') {
-        success();
-    }
-};
-
 exports.getToken = function (success, error) {
     if (typeof success === 'function') {
         success();

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -4,10 +4,6 @@ exports.getVerificationID = function (number, success, error) {
     exec(success, error, "FirebasePlugin", "getVerificationID", [number]);
 };
 
-exports.getInstanceId = function (success, error) {
-    exec(success, error, "FirebasePlugin", "getInstanceId", []);
-};
-
 exports.getId = function (success, error) {
     exec(success, error, "FirebasePlugin", "getId", []);
 };


### PR DESCRIPTION
Firebase iOS 6.x has many [breaking changes](https://firebase.google.com/support/release-notes/ios#version_600_-_may_7_2019) which is not yet supported by the code of this plugin. So using the last version Firebase iOS SDK 5.x i.e. 5.20.2